### PR TITLE
Include submitted fields in manager notification email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.mo
+/*.egg-info

--- a/collective/signupsheet/adapters/initialize_signup_sheet_form.py
+++ b/collective/signupsheet/adapters/initialize_signup_sheet_form.py
@@ -144,19 +144,22 @@ class InitializeSignupSheetForm(object):
                                   mapping={'title': form_name}),
                                 context=self.form.REQUEST,)
             mailer.setMsg_subject(subject)
-            mailer.setBody_pt(MANAGER_MAIL % translate(
-                               _(u'manager_subscription_mail',
+            mailer.setBody_pt(MANAGER_MAIL % (
+                    translate(_(u'manager_subscription_mail_header',
                                 default=u"""<p>
-    New registrant registered to <tal:s tal:content="here/aq_inner/aq_parent/Title" />
+    New registrant registered to <tal:s tal:content="here/aq_inner/aq_parent/Title" />:
 </p>
-
-<p>
+"""),
+                                context=self.form.REQUEST),
+                    translate(_(u'manager_subscription_mail_footer',
+                                default=u"""<p>
     Please check current registrants status at:
     <a href="" tal:attributes="href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants"
        tal:content="string:${here/aq_inner/aq_parent/absolute_url}/view_registrants">
     </a>
 </p>"""),
-                                context=self.form.REQUEST),)
+                                context=self.form.REQUEST)
+                    ) )
             mailer.setExecCondition("python: here.restrictedTraverse('@@check_manager_mail_form')()")
             self.form._pfFixup(mailer)
 

--- a/collective/signupsheet/config.py
+++ b/collective/signupsheet/config.py
@@ -39,6 +39,15 @@ MANAGER_MAIL = u"""<html xmlns="http://www.w3.org/1999/xhtml">
 
 %s
 
+<dl tal:condition="options/wrappedFields|nothing">
+    <tal:block repeat="field options/wrappedFields">
+        <dt tal:content="field/fgField/widget/label" />
+        <dd tal:content="structure python:field.htmlValue(request)" />
+    </tal:block>
+</dl>
+
+%s
+
 </body>
 </html>
 """

--- a/collective/signupsheet/locales/collective.signupsheet.pot
+++ b/collective/signupsheet/locales/collective.signupsheet.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.signupsheet\n"
 
+#: ../configure.zcml:28
 msgid "A solution for manage signup attendance to events"
 msgstr ""
 
@@ -56,6 +57,10 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
+#: ../configure.zcml:53
+msgid "Migrate SignupSheet to version 0.2"
+msgstr ""
+
 #: ../browsers/registrants_data.py:175
 msgid "No file loaded"
 msgstr ""
@@ -68,12 +73,24 @@ msgstr ""
 msgid "Registration deadline"
 msgstr ""
 
+#: ../configure.zcml:36
+msgid "Remove collective.signupsheet"
+msgstr ""
+
 #: ../browsers/registrants_notification.pt:141
 msgid "Send"
 msgstr ""
 
 #: ../profiles/default/types/SignupSheet.xml
 msgid "Signup Sheet"
+msgstr ""
+
+#: ../configure.zcml:28
+msgid "SignupSheet"
+msgstr ""
+
+#: ../configure.zcml:36
+msgid "SignupSheet: uninstall"
 msgstr ""
 
 #: ../skins/collective_signupsheet/ss_base_view_p3.cpt:115
@@ -229,9 +246,14 @@ msgstr ""
 msgid "mailer_registration_subject_overrides_manager"
 msgstr ""
 
-#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />\n</p>\n\n<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
+#. Default: "<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
+#: ../adapters/initialize_signup_sheet_form.py:154
+msgid "manager_subscription_mail_footer"
+msgstr ""
+
+#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />:\n</p>\n"
 #: ../adapters/initialize_signup_sheet_form.py:148
-msgid "manager_subscription_mail"
+msgid "manager_subscription_mail_header"
 msgstr ""
 
 #. Default: "Message is required. Please provide it"
@@ -260,7 +282,7 @@ msgid "pfg_registrants_title"
 msgstr ""
 
 #. Default: "Thank You"
-#: ../adapters/initialize_signup_sheet_form.py:168
+#: ../adapters/initialize_signup_sheet_form.py:171
 msgid "pfg_thankyou_title"
 msgstr ""
 
@@ -384,7 +406,7 @@ msgid "text_registration_full"
 msgstr ""
 
 #. Default: "Thank you for registering, we will contact you shortly. <br/>\nYou provided the following information:"
-#: ../adapters/initialize_signup_sheet_form.py:171
+#: ../adapters/initialize_signup_sheet_form.py:174
 msgid "thanks_prologue"
 msgstr ""
 
@@ -405,4 +427,3 @@ msgstr ""
 #: ../browsers/view_registrants.pt:21
 msgid "view_registrants"
 msgstr ""
-

--- a/collective/signupsheet/locales/de/LC_MESSAGES/collective.signupsheet.po
+++ b/collective/signupsheet/locales/de/LC_MESSAGES/collective.signupsheet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: 2013-01-16 13:45 +ZONE\n"
 "Last-Translator: Stephan Klinger <staeff@arcor.de>\n"
 "Language-Team: de <staeff@arcor.de>\n"
@@ -15,6 +15,7 @@ msgstr ""
 "Domain: collective.signupsheet\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
+#: ../configure.zcml:28
 msgid "A solution for manage signup attendance to events"
 msgstr "Ein Produkt zur Verwaltung von Veranstaltungsanmeldungen"
 
@@ -54,6 +55,10 @@ msgstr "Teilnehmerdaten bearbeiten"
 msgid "Import"
 msgstr "Importieren"
 
+#: ../configure.zcml:53
+msgid "Migrate SignupSheet to version 0.2"
+msgstr ""
+
 #: ../browsers/registrants_data.py:175
 msgid "No file loaded"
 msgstr "Keine Datei geladen"
@@ -66,6 +71,10 @@ msgstr ""
 msgid "Registration deadline"
 msgstr "Anmeldeschluss"
 
+#: ../configure.zcml:36
+msgid "Remove collective.signupsheet"
+msgstr ""
+
 #: ../browsers/registrants_notification.pt:141
 msgid "Send"
 msgstr ""
@@ -73,6 +82,14 @@ msgstr ""
 #: ../profiles/default/types/SignupSheet.xml
 msgid "Signup Sheet"
 msgstr "Signup Sheet"
+
+#: ../configure.zcml:28
+msgid "SignupSheet"
+msgstr ""
+
+#: ../configure.zcml:36
+msgid "SignupSheet: uninstall"
+msgstr ""
 
 #: ../skins/collective_signupsheet/ss_base_view_p3.cpt:115
 msgid "The registration is closed"
@@ -229,12 +246,20 @@ msgstr "Ihre Anmeldung für ${title} wurde empfangen"
 msgid "mailer_registration_subject_overrides_manager"
 msgstr "Benachrichtigung: Eine neue Anmeldung für ${title} wurde empfangen"
 
-#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />\n</p>\n\n<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
-#: ../adapters/initialize_signup_sheet_form.py:148
-msgid "manager_subscription_mail"
+#. Default: "<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
+#: ../adapters/initialize_signup_sheet_form.py:154
+msgid "manager_subscription_mail_footer"
 msgstr ""
-"Neue Anmeldung von <tal:s tal:content='here/aq_inner/aq_parent/Title'/><br/>\n"
-"Bestätigen sie die Anmeldung hier: <tal:s tal:content='string:${here/aq_inner/aq_parent/absolute_url}/view_registrants' />"
+"<p>\n"
+"Bestätigen sie die Anmeldung hier: <tal:s tal:content='string:${here/aq_inner/aq_parent/absolute_url}/view_registrants' />\n"
+"</p>"
+
+#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />:\n</p>\n"
+#: ../adapters/initialize_signup_sheet_form.py:148
+msgid "manager_subscription_mail_header"
+msgstr ""
+"<p>\n"
+"Neue Anmeldung von <tal:s tal:content='here/aq_inner/aq_parent/Title'/>:</p>\n"
 
 #. Default: "Message is required. Please provide it"
 #: ../browsers/registrants_notification.py:45
@@ -263,7 +288,7 @@ msgid "pfg_registrants_title"
 msgstr "Teilnehmer Adapter"
 
 #. Default: "Thank You"
-#: ../adapters/initialize_signup_sheet_form.py:168
+#: ../adapters/initialize_signup_sheet_form.py:171
 msgid "pfg_thankyou_title"
 msgstr "Vielen Dank"
 
@@ -389,7 +414,7 @@ msgid "text_registration_full"
 msgstr "Die Veranstaltung ist ausgebucht"
 
 #. Default: "Thank you for registering, we will contact you shortly. <br/>\nYou provided the following information:"
-#: ../adapters/initialize_signup_sheet_form.py:171
+#: ../adapters/initialize_signup_sheet_form.py:174
 msgid "thanks_prologue"
 msgstr ""
 "Vielen Dank für Ihre Anmeldung, wir werden Sie in Kürze kontaktieren. <br/>\n"
@@ -412,4 +437,3 @@ msgstr "Anmeldedaten exportieren"
 #: ../browsers/view_registrants.pt:21
 msgid "view_registrants"
 msgstr "Teilnehmer anzeigen"
-

--- a/collective/signupsheet/locales/de/LC_MESSAGES/plone.po
+++ b/collective/signupsheet/locales/de/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -86,4 +86,3 @@ msgstr "Nicht bestätigt. In der Warteliste"
 #: ../profiles/default/types/SignupSheet.xml
 msgid "View Registrants"
 msgstr "Teilnehmer anzeigen"
-

--- a/collective/signupsheet/locales/it/LC_MESSAGES/collective.signupsheet.po
+++ b/collective/signupsheet/locales/it/LC_MESSAGES/collective.signupsheet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: 2013-01-16 13:45 +ZONE\n"
 "Last-Translator: Luca Bellenghi <luca.bellenghi@redturtle.it>\n"
 "Language-Team: RedTurtle Technology <sviluppo@redturtle.it>\n"
@@ -15,6 +15,7 @@ msgstr ""
 "Domain: collective.signupsheet\n"
 "X-Is-Fallback-For: it-ch it-it\n"
 
+#: ../configure.zcml:28
 msgid "A solution for manage signup attendance to events"
 msgstr "Una soluzione per la gestione di iscrizione ad eventi"
 
@@ -54,6 +55,10 @@ msgstr "Modifica i dati dell'iscrizione"
 msgid "Import"
 msgstr "Importa"
 
+#: ../configure.zcml:53
+msgid "Migrate SignupSheet to version 0.2"
+msgstr ""
+
 #: ../browsers/registrants_data.py:175
 msgid "No file loaded"
 msgstr "Nessun file caricato"
@@ -66,6 +71,10 @@ msgstr "Notifica iscritti"
 msgid "Registration deadline"
 msgstr "Scadenza dell'iscrizione"
 
+#: ../configure.zcml:36
+msgid "Remove collective.signupsheet"
+msgstr ""
+
 #: ../browsers/registrants_notification.pt:141
 msgid "Send"
 msgstr "Invia"
@@ -73,6 +82,14 @@ msgstr "Invia"
 #: ../profiles/default/types/SignupSheet.xml
 msgid "Signup Sheet"
 msgstr "Gestore Iscrizioni"
+
+#: ../configure.zcml:28
+msgid "SignupSheet"
+msgstr ""
+
+#: ../configure.zcml:36
+msgid "SignupSheet: uninstall"
+msgstr ""
 
 #: ../skins/collective_signupsheet/ss_base_view_p3.cpt:115
 msgid "The registration is closed"
@@ -229,20 +246,24 @@ msgstr "La sua registrazione a \"${title}\" è stata ricevuta"
 msgid "mailer_registration_subject_overrides_manager"
 msgstr "E' stata ricevuta una nuova registrazione per \"${title}\""
 
-#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />\n</p>\n\n<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
-#: ../adapters/initialize_signup_sheet_form.py:148
-msgid "manager_subscription_mail"
+#. Default: "<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
+#: ../adapters/initialize_signup_sheet_form.py:154
+msgid "manager_subscription_mail_footer"
 msgstr ""
-"<p>\n"
-"    Un nuovo iscritto si è registrato a <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />\n"
-"</p>\n"
-"\n"
 "<p>\n"
 "Prego verificare lo stato degli iscritti al seguente indirizzo:\n"
 "    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n"
 "       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n"
 "    </a>\n"
 "</p>"
+
+#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />:\n</p>\n"
+#: ../adapters/initialize_signup_sheet_form.py:148
+msgid "manager_subscription_mail_header"
+msgstr ""
+"<p>\n"
+"    Un nuovo iscritto si è registrato a <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />:\n"
+"</p>\n"
 
 #. Default: "Message is required. Please provide it"
 #: ../browsers/registrants_notification.py:45
@@ -270,7 +291,7 @@ msgid "pfg_registrants_title"
 msgstr "Iscritti"
 
 #. Default: "Thank You"
-#: ../adapters/initialize_signup_sheet_form.py:168
+#: ../adapters/initialize_signup_sheet_form.py:171
 msgid "pfg_thankyou_title"
 msgstr "Grazie!"
 
@@ -403,7 +424,7 @@ msgid "text_registration_full"
 msgstr "L'iscrizione è al completo"
 
 #. Default: "Thank you for registering, we will contact you shortly. <br/>\nYou provided the following information:"
-#: ../adapters/initialize_signup_sheet_form.py:171
+#: ../adapters/initialize_signup_sheet_form.py:174
 msgid "thanks_prologue"
 msgstr ""
 "La ringraziamo per la registrazione, verrà contattato a breve. <br/>\n"

--- a/collective/signupsheet/locales/it/LC_MESSAGES/plone.po
+++ b/collective/signupsheet/locales/it/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -86,4 +86,3 @@ msgstr "Non confermato, in lista d'attesa"
 #: ../profiles/default/types/SignupSheet.xml
 msgid "View Registrants"
 msgstr "Vedi gli iscritti"
-

--- a/collective/signupsheet/locales/no/LC_MESSAGES/collective.signupsheet.po
+++ b/collective/signupsheet/locales/no/LC_MESSAGES/collective.signupsheet.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: 2015-02-06 15:31+0100\n"
 "Last-Translator: Eivind Sætre <eivind.saetre@gmail.com>\n"
 "Language-Team: \n"
@@ -16,6 +16,7 @@ msgstr ""
 "Language: no\n"
 "X-Generator: Poedit 1.7.4\n"
 
+#: ../configure.zcml:28
 msgid "A solution for manage signup attendance to events"
 msgstr "En løsning for å behandle påmeldinger til arrangementer"
 
@@ -55,6 +56,10 @@ msgstr "Rediger opplysninger om den påmeldte"
 msgid "Import"
 msgstr "Importer"
 
+#: ../configure.zcml:53
+msgid "Migrate SignupSheet to version 0.2"
+msgstr ""
+
 #: ../browsers/registrants_data.py:175
 msgid "No file loaded"
 msgstr "Ingen fil valgt"
@@ -67,6 +72,10 @@ msgstr "Beskjed til påmeldte"
 msgid "Registration deadline"
 msgstr "Tidsfrist for påmelding"
 
+#: ../configure.zcml:36
+msgid "Remove collective.signupsheet"
+msgstr ""
+
 #: ../browsers/registrants_notification.pt:141
 msgid "Send"
 msgstr "Send"
@@ -74,6 +83,14 @@ msgstr "Send"
 #: ../profiles/default/types/SignupSheet.xml
 msgid "Signup Sheet"
 msgstr "Påmeldingsskjema"
+
+#: ../configure.zcml:28
+msgid "SignupSheet"
+msgstr ""
+
+#: ../configure.zcml:36
+msgid "SignupSheet: uninstall"
+msgstr ""
 
 #: ../skins/collective_signupsheet/ss_base_view_p3.cpt:115
 msgid "The registration is closed"
@@ -228,20 +245,24 @@ msgstr "Din påmelding til \"${title}\" er mottatt"
 msgid "mailer_registration_subject_overrides_manager"
 msgstr "En ny påmelding til \"${title}\" har kommet inn"
 
-#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />\n</p>\n\n<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
-#: ../adapters/initialize_signup_sheet_form.py:148
-msgid "manager_subscription_mail"
+#. Default: "<p>\n    Please check current registrants status at:\n    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n    </a>\n</p>"
+#: ../adapters/initialize_signup_sheet_form.py:154
+msgid "manager_subscription_mail_footer"
 msgstr ""
-"<p>\n"
-"    Ny påmelding til <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />\n"
-"</p>\n"
-"\n"
 "<p>\n"
 "    Vennligst undersøk den påmeldtes status her:\n"
 "    <a href=\"\" tal:attributes=\"href string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\"\n"
 "       tal:content=\"string:${here/aq_inner/aq_parent/absolute_url}/view_registrants\">\n"
 "    </a>\n"
 "</p>"
+
+#. Default: "<p>\n    New registrant registered to <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />:\n</p>\n"
+#: ../adapters/initialize_signup_sheet_form.py:148
+msgid "manager_subscription_mail_header"
+msgstr ""
+"<p>\n"
+"    Ny påmelding til <tal:s tal:content=\"here/aq_inner/aq_parent/Title\" />:\n"
+"</p>\n"
 
 #. Default: "Message is required. Please provide it"
 #: ../browsers/registrants_notification.py:45
@@ -269,7 +290,7 @@ msgid "pfg_registrants_title"
 msgstr "Påmeldte"
 
 #. Default: "Thank You"
-#: ../adapters/initialize_signup_sheet_form.py:168
+#: ../adapters/initialize_signup_sheet_form.py:171
 msgid "pfg_thankyou_title"
 msgstr "Takk"
 
@@ -402,7 +423,7 @@ msgid "text_registration_full"
 msgstr "Arrangementet er fulltegnet"
 
 #. Default: "Thank you for registering, we will contact you shortly. <br/>\nYou provided the following information:"
-#: ../adapters/initialize_signup_sheet_form.py:171
+#: ../adapters/initialize_signup_sheet_form.py:174
 msgid "thanks_prologue"
 msgstr ""
 "Takk for din påmelding, vi kontakter deg snarlig. <br/>\n"
@@ -425,4 +446,3 @@ msgstr "Eksporter påmeldte"
 #: ../browsers/view_registrants.pt:21
 msgid "view_registrants"
 msgstr "Vis påmeldte"
-

--- a/collective/signupsheet/locales/no/LC_MESSAGES/plone.po
+++ b/collective/signupsheet/locales/no/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,4 +85,3 @@ msgstr ""
 #: ../profiles/default/types/SignupSheet.xml
 msgid "View Registrants"
 msgstr ""
-

--- a/collective/signupsheet/locales/plone.pot
+++ b/collective/signupsheet/locales/plone.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-18 12:58+0000\n"
+"POT-Creation-Date: 2018-02-02 23:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,4 +88,3 @@ msgstr ""
 #: ../profiles/default/types/SignupSheet.xml
 msgid "View Registrants"
 msgstr ""
-


### PR DESCRIPTION
Currently the manager email does not include submitted fields (as reported in #14), but rather only this:
```
New registrant registered to [Title]

Please check current registrants status at: [URL]
```
I've fixed the message template to include the fields (based on the user notification template), and have tested that it works correctly for all possibilities:
1. Include All Fields is checked
2. Include All is unchecked and no fields are chosen
3. Include All is unchecked and some fields are selected

To avoid needing new translations, I inserted the submitted fields into the middle of the template, so it now looks like:
```
New registrant registered to [Title]:
[ submitted fields, e.g. name, email, etc. ]

Please check current registrants status at: [URL]
```
I split the template into a header and footer, and added a colon to the end of the header.  Hopefully the indentation etc. is acceptable.

I'm not very familiar with Plone locales stuff but I added i18ndude to my buildout and ran `locales/rebuildPo.sh`, along with a small bit of manual editing to account for renamed fields.  This did generate some unrelated changes, including in the plone.po files, where it only updated the timestamp.  I can rebase without those if desired.

I also tested setting my site to different languages (de, it, no) and creating new test registrations, and all appear to function properly.